### PR TITLE
chore(ci): nvidia 470 no longer builds for asus 39

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -72,6 +72,10 @@ jobs:
           # Only build latest nvidia version for F40 (temporarily broken? not building in akmods)
           - fedora_version: 40
             nvidia_version: 470
+          # Nvidia 470 no longer builds for Asus on F39
+          - fedora_version: 39
+            hwe_flavor: asus
+            nvidia_version: 470
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
Just a cleanup since this build is failing and won't be resolved due to rpmfusion dropping nvidia 470.