### PR TITLE
fix(surface): Camera support

### DIFF
--- a/surface/packages.json
+++ b/surface/packages.json
@@ -2,7 +2,12 @@
     "all": {
         "include": {
             "all": [
-                "fprintd"
+                "fprintd",
+                "libcamera",
+                "libcamera-tools",
+                "libcamera-gstreamer",
+                "libcamera-ipa",
+                "pipewire-plugin-libcamera"
             ]
         },
         "exclude": {


### PR DESCRIPTION
Fix for #257 

Adding Libraries needed for Camera support on most Surfaces  https://github.com/linux-surface/linux-surface/wiki/Camera-Support#libcamera-support

tested on a Surface Go 8GB  (IR Camera needed to be disabled in BIOS)