### PR TITLE
fix(nvidia): pin Nvidia drivers to 555

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,7 +32,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp
 
-FROM ghcr.io/${SOURCE_ORG}/akmods-nvidia:${KERNEL_FLAVOR}-${FEDORA_MAJOR_VERSION} AS akmods_nvidia
+FROM ghcr.io/${SOURCE_ORG}/akmods-nvidia:${KERNEL_FLAVOR}-${FEDORA_MAJOR_VERSION}-20240806 AS akmods_nvidia
 
 FROM main AS nvidia
 

--- a/Containerfile
+++ b/Containerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp
 
+# Pin the NVIDIA images to the last build of the 555 driver due to issues with monitor freezing on the newer 560 drivers
 FROM ghcr.io/${SOURCE_ORG}/akmods-nvidia:${KERNEL_FLAVOR}-${FEDORA_MAJOR_VERSION}-20240806 AS akmods_nvidia
 
 FROM main AS nvidia


### PR DESCRIPTION
We have been experiencing multiple freezes with the newly released Nvidia 560 drivers, so we will pin to 555 while we investigate.

Depending on what Bazzite chooses to do, we may decide to unpin when they confirm everything is working well. 