### PR TITLE
Revert "fix(nvidia): pin Nvidia drivers to 555 (#273)"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,8 +32,7 @@ RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp
 
-# Pin the NVIDIA images to the last build of the 555 driver due to issues with monitor freezing on the newer 560 drivers
-FROM ghcr.io/${SOURCE_ORG}/akmods-nvidia:${KERNEL_FLAVOR}-${FEDORA_MAJOR_VERSION}-20240806 AS akmods_nvidia
+FROM ghcr.io/${SOURCE_ORG}/akmods-nvidia:${KERNEL_FLAVOR}-${FEDORA_MAJOR_VERSION} AS akmods_nvidia
 
 FROM main AS nvidia
 


### PR DESCRIPTION
akmods now properly builds the proprietary driver. Users are also seeing mixed packages so this must go.