### PR TITLE
refactor: simpler nvidia kernel.conf fix

### DIFF
--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -49,11 +49,7 @@ rpm-ostree install \
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/{eyecantcu-supergfxctl,negativo17-fedora-nvidia,nvidia-container-toolkit}.repo
 
 # ensure kernel.conf matches NVIDIA_FLAVOR (which must be nvidia or nvidia-open)
-# kmod-nvidia-common defaults the value to 'nvidia-open' but this will match on $NVIDIA_FLAVOR
-KERNEL_MODULE_TYPE="kernel"
-if [[ "${NVIDIA_FLAVOR}" == "nvidia-open" ]]; then
-  KERNEL_MODULE_TYPE="kernel-open"
-fi
+# kmod-nvidia-common defaults to 'nvidia-open' but this will match our akmod image
 sed -i "s/^MODULE_VARIANT=.*/MODULE_VARIANT=$KERNEL_MODULE_TYPE/" /etc/nvidia/kernel.conf
 
 systemctl enable nvidia-persistenced.service


### PR DESCRIPTION
Upon closer inspection our akmod image already fprovides the KERNEL_MODULE_TYPE variable so no need to compute it.

Relates: #286