### PR TITLE
feat(ci): enable Fedora 41 builds

### DIFF
--- a/.github/workflows/build-41.yml
+++ b/.github/workflows/build-41.yml
@@ -1,0 +1,15 @@
+name: ublue hwe 41
+on:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 4 * * *'  # 4:00-ish UTC everyday
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      fedora_version: 41

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -48,6 +48,8 @@ jobs:
           # There is no more asus on Fedora -1
           - kernel_flavor: asus
             fedora_version: 39
+          - kernel_flavor: surface
+            fedora_version: 41
 
     steps:
       # Checkout push-to-registry action GitHub repository


### PR DESCRIPTION
Surface images are the only ones excluded since there are no F41 kernels yet