### PR TITLE
fix: nvidia fixes

### DIFF
--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -60,7 +60,10 @@ semodule --verbose --install /usr/share/selinux/packages/nvidia-container.pp
 # Universal Blue specific Initramfs fixes
 echo "options nvidia NVreg_TemporaryFilePath=/var/tmp" >> /usr/lib/modprobe.d/nvidia-atomic.conf
 cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
+# we must force driver load to fix black screen on boot for nvidia desktops
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+# as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
+sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia-dracut.conf
 
 if [[ "${IMAGE_NAME}" == "sericea" ]]; then
     mv /etc/sway/environment{,.orig}

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -63,7 +63,7 @@ cp /etc/modprobe.d/nvidia-modeset.conf /usr/lib/modprobe.d/nvidia-modeset.conf
 # we must force driver load to fix black screen on boot for nvidia desktops
 sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
-sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia-dracut.conf
+sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
 if [[ "${IMAGE_NAME}" == "sericea" ]]; then
     mv /etc/sway/environment{,.orig}

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -65,6 +65,9 @@ sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
 sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
+# delete forced power managemant to instead allow driver default (fixes ampere+ optimus D3cold state)
+sed '/^.*NVreg_DynamicPowerManagement.*/d' /usr/lib/modprobe.d/nvidia.conf
+
 if [[ "${IMAGE_NAME}" == "sericea" ]]; then
     mv /etc/sway/environment{,.orig}
     install -Dm644 /usr/share/ublue-os/etc/sway/environment /etc/sway/environment


### PR DESCRIPTION
fix: chromium browser use of hw accel on hybrid laptops

This has been tested via live-stream with multiple ublue-os team members.

We concur that this will retain the fix of pre-loaded nvidia which enables plymouth boot screen to show rather than only a blank screen.

This will, however, pre-load i915 & amdgpu drivers on all nvidia machines, even desktops which only have discrete nvidia cards. It's a fair compromise for us suckers who run nvidia, to have an image which works for all. A loaded kmod which doesn't have any actual hardware though, does not cause harm, just a bit of extra memory used.

The group deemed it a fair trade off for now.

Fixes: #285

fix: use default nvidia driver power management

This fixes power management on optimus laptops, specifically for Ampere+
where the specified config was preventing D3cold state.

Upstream negativo17 should be notified of this change, too.

Fixes: #290