### PR TITLE
chore: update build badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HWE
 
-[![build-39](https://github.com/ublue-os/hwe/actions/workflows/build-39.yml/badge.svg)](https://github.com/ublue-os/hwe/actions/workflows/build-39.yml) [![build-40](https://github.com/ublue-os/hwe/actions/workflows/build-40.yml/badge.svg)](https://github.com/ublue-os/hwe/actions/workflows/build-40.yml)
+[![build-41](https://github.com/ublue-os/hwe/actions/workflows/build-41.yml/badge.svg)](https://github.com/ublue-os/hwe/actions/workflows/build-41.yml) [![build-40](https://github.com/ublue-os/hwe/actions/workflows/build-40.yml/badge.svg)](https://github.com/ublue-os/hwe/actions/workflows/build-40.yml)
 
 The purpose of these images is to provide [community Fedora images](https://github.com/ublue-os/main) with hardware enablement (ASUS and Surface) and Nvidia. This approach can lead to greater reliability as failures can be caught at the build level instead of the client machine. This also allows for individual sets of images for each series of Nvidia drivers, allowing users to remain current with their OS but on an older, known working driver. Performance regression with a recent driver update? Reboot into a known-working driver after one command. That's the goal!
 


### PR DESCRIPTION
The build badges are still for Fedora 39 and 40. This PR bumps them to 40 and 41.