### PR TITLE
fix(ci): ensure use of negativo17-nvidia repo (not multimedia)

### DIFF
--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -15,7 +15,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion*.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 
 ## nvidia install steps
-"${INSTALL}" /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
+${INSTALL} /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
 # enable repos provided by ublue-os-nvidia-addons
 sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' /etc/yum.repos.d/negativo17-fedora-nvidia.repo
@@ -47,7 +47,7 @@ else
     VARIANT_PKGS=""
 fi
 
-"${INSTALL}" \
+${INSTALL} \
     libnvidia-fbc \
     libnvidia-ml.i686 \
     libva-nvidia-driver \

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -2,13 +2,6 @@
 
 set -oux pipefail
 
-RELEASE="$(rpm -E %fedora)"
-
-# disable any remaining rpmfusion repos
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion*.repo
-
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
-
 # disable negativo17-mutlimedia only if enabled; restore state later
 NEGATIVO17_MULT_PREV_ENABLED=N
 if [[ -n $(grep enabled=1 /etc/yum.repos.d/negativo17-fedora-multimedia.repo ) ]]; then
@@ -18,6 +11,13 @@ if [[ -n $(grep enabled=1 /etc/yum.repos.d/negativo17-fedora-multimedia.repo ) ]
 fi
 
 set -e
+
+RELEASE="$(rpm -E %fedora)"
+
+# disable any remaining rpmfusion repos
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/rpmfusion*.repo
+
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 
 ## nvidia install steps
 rpm-ostree install /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm


### PR DESCRIPTION
This should ensure that all our nvidia builds (including HWE, Aurora, Bazzite, Bluefin) use the negativo17-nvidia repo which is what we use to build the nvidia-kmod, even if those builds also use negativo17-multimedia. 

