### PR TITLE
Add builds for Fedora 42

### DIFF
--- a/.github/workflows/build-42.yml
+++ b/.github/workflows/build-42.yml
@@ -1,0 +1,15 @@
+name: ublue hwe 42
+on:
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 4 * * *'  # 4:00-ish UTC everyday
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      fedora_version: 42 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -28,8 +28,6 @@ jobs:
           - ${{ inputs.fedora_version }}
         kernel_flavor:
           - main
-          - asus # Remove when F42 releases
-          - surface # Remove when F42 releases
         image_name:
           - silverblue
           - kinoite
@@ -50,8 +48,14 @@ jobs:
             fedora_version: 39
           - kernel_flavor: asus
             fedora_version: 40
+          - kernel_flavor: asus
+            fedora_version: 41
+          - kernel_flavor: asus
+            fedora_version: 42
           - kernel_flavor: surface
             fedora_version: 41
+          - kernel_flavor: surface
+            fedora_version: 42
 
     steps:
       # Checkout push-to-registry action GitHub repository
@@ -95,6 +99,11 @@ jobs:
             IS_GTS_VERSION=true
             IS_BETA_VERSION=false
           elif [[ "${{ matrix.fedora_version }}" -eq "41" ]]; then
+            IS_LATEST_VERSION=false
+            IS_STABLE_VERSION=true
+            IS_GTS_VERSION=false
+            IS_BETA_VERSION=false
+          elif [[ "${{ matrix.fedora_version }}" -eq "42" ]]; then
             IS_LATEST_VERSION=true
             IS_STABLE_VERSION=true
             IS_GTS_VERSION=false

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -45,8 +45,6 @@ jobs:
             image_target: main
           # There is no more asus on Fedora -1
           - kernel_flavor: asus
-            fedora_version: 39
-          - kernel_flavor: asus
             fedora_version: 40
           - kernel_flavor: asus
             fedora_version: 41
@@ -55,6 +53,22 @@ jobs:
           - kernel_flavor: surface
             fedora_version: 41
           - kernel_flavor: surface
+            fedora_version: 42
+          # A new naming convention is used in F42+ for some images
+          # It's hacky, but it's a temporary solution until we move
+          # Nvidia builds into ublue-os/main
+          - image_name: sericea
+            fedora_version: 42
+          - image_name: onyx
+            fedora_version: 42
+          - image_name: lazurite
+            fedora_version: 42
+          - image_name: vauxite
+            fedora_version: 42
+        include:
+          - image_name: budgie-atomic
+            fedora_version: 42
+          - image_name: sway-atomic
             fedora_version: 42
 
     steps:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -68,8 +68,12 @@ jobs:
         include:
           - image_name: budgie-atomic
             fedora_version: 42
+            kernel_flavor: main
+            image_target: nvidia
           - image_name: sway-atomic
             fedora_version: 42
+            kernel_flavor: main
+            image_target: nvidia
 
     steps:
       # Checkout push-to-registry action GitHub repository
@@ -189,7 +193,7 @@ jobs:
       - name: Verify akmods-nvidia image
         uses: EyeCantCU/cosign-action/verify@v0.3.0
         with:
-          containers: akmods-nvidia:${{ matrix.kernel_flavor}}-${{ matrix.fedora_version }}
+          containers: akmods-nvidia:${{ matrix.kernel_flavor }}-${{ matrix.fedora_version }}
           registry: ${{ env.IMAGE_REGISTRY }}
 
       - name: Get current version


### PR DESCRIPTION
Adds a build for Fedora 42. I'm not super familiar with the tag lifecycle, but I think I've got them correct. 42 is `latest` and `beta`, 41 is `stable` and 40 is `gts`.